### PR TITLE
Purge split

### DIFF
--- a/Documentation/Commands/purge.md
+++ b/Documentation/Commands/purge.md
@@ -1,13 +1,49 @@
 # Purge
 
-Purges a specified number of messages from the current channel. Defaults to 10 if no number is specified.
+The `Purge` commands allow you to delete messages from a channel based on the amount specified or until a specific message is reached.
 
-### Usage
+### Commands
 
-`/purge <amount> <afterMessage>`
+#### 1. `/purge amount`
 
-### Arguments
-- `<amount (int:1~250)=10>`: The amount of messages to purge from the channel.
-- `<afterMessage (message)>`: The message link or ID to delete after. It itself will not get deleted.
+Purges a specified number of messages from the current channel. The number of messages to be purged can range from 1 to 250, with the default being 10 if no number is specified.
 
-**Note:** This command will execute one API request per 100 messages.
+**Usage:**
+
+`/purge amount <amount>`
+
+**Arguments:**
+
+- `<amount (int:1~250)=10>`: The number of messages to purge from the channel.
+
+**Example:**
+
+- `/purge amount 50` - Purges 50 messages from the current channel.
+
+---
+
+#### 2. `/purge until`
+
+Purges messages from the current channel until a certain message is reached. You can specify whether or not the target message itself should be deleted.
+
+**Usage:**
+
+`/purge until [message] <inclusive>`
+
+**Arguments:**
+
+- `<message (message)>`: The message link or ID to delete messages until.
+- `[inclusive (bool)=false]`: Whether or not to delete the provided message as well. Defaults to `false`.
+
+**Example:**
+
+- `/purge until 123456789012345678` - Purges all messages after the specified message ID, but does not delete the specified message itself.
+- `/purge until 123456789012345678 true` - Purges all messages after and including the specified message ID.
+
+---
+
+**Notes** 
+- The `message` argument can accept either a message ID or a message link. 
+- This command will purge messages in bulk, making one API request per 100 messages.
+
+---

--- a/Documentation/usage.md
+++ b/Documentation/usage.md
@@ -33,7 +33,7 @@ Data types are put after the argument name, such as `[myArg (string)]`, and can 
 - `user`: A username (not display name!), ID or ping, such as `wumpus`, `@wumpus`, `123456789123456789`, or `<@123456789123456789>` (which is what Discord does by default if you type @ and the user).
 - `channel`: A channel ID, link or reference, such as `1234567890123456789`, `https://discord.com/channels/9876543210987654321/1234567890123456789`, or `<#1234567890123456789>` (which is what Discord does by default if you type # and the channel name).
 - `role`: A role ID, name or reference, such as `1234567890123456789`, `my role` (name must be exact, but it's not case-sensitive), or `<@&1234567890123456789>` (which is what Discord does by default if you type @ and the role).
-- `message`: A message ID or link, such as `123123123123123123` or `https://discord.com/channels/9876543210987654321/1234567890123456789/123123123123123123`. For technical reasons, the message must be in the same and channel as the command is run in, unless a separate channel argument is provided. 
+- `message`: A message ID or link, such as `123123123123123123` or `https://discord.com/channels/9876543210987654321/1234567890123456789/123123123123123123`.
 
 #### Lists
 

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -9,7 +9,7 @@ namespace ArtcordAdminBot
     {
         public static async Task CommandErrored(CommandsExtension s, CommandErroredEventArgs e)
         {
-            await e.Context.RespondAsync(MessageHelpers.GenericErrorEmbed($"**{e.Exception.GetType().Name}**\n> {e.Exception.Message}"));
+            await e.Context.RespondAsync(MessageHelpers.GenericErrorEmbed($"**{e.Exception.GetType().Name}**\n> {e.Exception.Message}", title: "Error (D#+)"));
         }
     }
 }

--- a/Features/PurgeCommand.cs
+++ b/Features/PurgeCommand.cs
@@ -36,7 +36,7 @@ namespace ArtcordAdminBot.Features
                     messages.Add(message);
                 }
 
-                await RemoveMessagesAndRespondAsync(context, messages);
+                await RemoveMessagesAndRespondAsync(context, messages, context.Channel);
             }
             catch (ConversionHelpers.Exception ex)
             {
@@ -55,32 +55,47 @@ namespace ArtcordAdminBot.Features
         [Command("until")]
         [System.ComponentModel.Description("Purges until a certain message is reached from the channel.")]
         public static async Task PurgeUntilAsync(CommandContext context,
-            [System.ComponentModel.Description("The message link or ID to delete until.")] string untilMessage,
+            [System.ComponentModel.Description("The message link or ID to delete until.")] string message,
             [System.ComponentModel.Description("Whether or not to delete the provided message as well. (default False)")] bool inclusive = false)
         {
-            // Collect messages into a list
-            var messages = new List<DiscordMessage>();
-
-            ulong messageId = ConversionHelpers.GetMessageId(untilMessage, nameof(untilMessage), context);
-
-            await foreach (var message in context.Channel.GetMessagesAfterAsync(messageId))
+            try
             {
-                messages.Add(message);
-            }
-            if (inclusive) 
-            {
-                messages.Add(await context.Channel.GetMessageAsync(messageId));
-            }
+                // Collect messages into a list
+                var messages = new List<DiscordMessage>();
 
-            await RemoveMessagesAndRespondAsync(context, messages);
+                DiscordMessage discordMessage = await ConversionHelpers.GetMessage(message, nameof(message), context);
+
+                await foreach (var currentMessage in discordMessage.Channel.GetMessagesAfterAsync(discordMessage.Id))
+                {
+                    messages.Add(currentMessage);
+                }
+                if (inclusive)
+                {
+                    messages.Add(discordMessage);
+                }
+
+                await RemoveMessagesAndRespondAsync(context, messages, discordMessage.Channel);
+            }
+            catch (ConversionHelpers.Exception ex)
+            {
+                await context.RespondAsync(
+                    ex.ToEmbed()
+                );
+            }
+            catch (Exception ex)
+            {
+                await context.RespondAsync(
+                    MessageHelpers.GenericErrorEmbed($"An error occurred while purging messages:\n> {ex.Message}")
+                );
+            }
         }
 
-        private static async Task RemoveMessagesAndRespondAsync(CommandContext context, List<DiscordMessage> messages)
+        private static async Task RemoveMessagesAndRespondAsync(CommandContext context, List<DiscordMessage> messages, DiscordChannel channel)
         {
             // Bulk delete messages
             if (messages.Count > 0)
             {
-                await context.Channel.DeleteMessagesAsync(messages);
+                await channel.DeleteMessagesAsync(messages);
             }
             else
             {
@@ -91,7 +106,8 @@ namespace ArtcordAdminBot.Features
             }
 
             await context.RespondAsync(
-                    MessageHelpers.GenericSuccessEmbed("Purge complete!", $"Successfully deleted {messages.Count} message{(messages.Count == 1 ? "" : "s")}.")
+                    MessageHelpers.GenericSuccessEmbed("Purge complete!", $"Successfully deleted {messages.Count} message{(messages.Count == 1 ? "" : "s")}" +
+                    $"{(channel.Id != context.Channel.Id ? $" in {channel.Mention}" : "")}.")
                 );
         }
     }

--- a/Features/PurgeCommand.cs
+++ b/Features/PurgeCommand.cs
@@ -20,7 +20,7 @@ namespace ArtcordAdminBot.Features
             try
             {
                 // Ensure the count is within range
-                if (amount <= 1 || amount > 250)
+                if (amount < 1 || amount > 250)
                 {
                     await context.RespondAsync(
                         MessageHelpers.GenericErrorEmbed("A number from **1** to **250** must be provided for the parameter `amount`.")


### PR DESCRIPTION
- Split /purge amount and /purge until
- Renamed `after` to `until` and added extra argument `inclusive`
- Made it so it's possible to purge messages from other channels as well
- Additional improvements

Todo: Update readme!